### PR TITLE
fix: wasm-opt options

### DIFF
--- a/src/cmd/opt.js
+++ b/src/cmd/opt.js
@@ -60,7 +60,7 @@ export async function optimizeComponent (componentBytes, opts) {
     }
 
     const optimizedCoreModules = await Promise.all(coreModules.map(async ([coreModuleStart, coreModuleEnd]) => {
-      const optimized = wasmOpt(componentBytes.subarray(coreModuleStart, coreModuleEnd), opts?.args);
+      const optimized = wasmOpt(componentBytes.subarray(coreModuleStart, coreModuleEnd), opts?.optArgs);
       if (spinner) {
         completed++;
         spinner.text = spinnerText();
@@ -124,7 +124,7 @@ export async function optimizeComponent (componentBytes, opts) {
  * @param {Uint8Array} source 
  * @returns {Promise<Uint8Array>}
  */
-async function wasmOpt (source, args = ['-tnh', '--gufa', '--flatten', '--rereloop', '-Oz', '-Oz', '--low-memory-unused']) {
+async function wasmOpt (source, args = ['-tnh', '--gufa', '--flatten', '--rereloop', '-Oz', '-Oz', '--low-memory-unused', '--enable-bulk-memory']) {
   try {
     return await spawnIOTmp(WASM_OPT, source, [
       ...args, '-o'


### PR DESCRIPTION
This fixes Wasm-opt options, ensuring that `--enable-bulk-memory` is on by default and that custom opt args are properly passed through.

Resolves https://github.com/bytecodealliance/js-component-tools/issues/9.