### PR TITLE
feat: raw bindgen option for custom wrapping

### DIFF
--- a/crates/js-component-bindgen-component/Cargo.toml
+++ b/crates/js-component-bindgen-component/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 anyhow = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true, optional = true }
-js-component-bindgen = { path = "../js-component-bindgen" }
+js-component-bindgen = { path = "../js-component-bindgen", features = ['raw-bindgen'] }
 wasmtime-environ = { workspace = true, features = ['component-model'] }
 wit-bindgen-guest-rust = { workspace = true, features = ['default'] }
 wit-component = { workspace = true }

--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -64,6 +64,7 @@ impl exports::Exports for JsComponentBindgenComponent {
             base64_cutoff: options.base64_cutoff.unwrap_or(5000) as usize,
             tla_compat: options.tla_compat.unwrap_or(false),
             valid_lifting_optimization: options.valid_lifting_optimization.unwrap_or(false),
+            raw_bindgen: false,
         };
 
         let js_component_bindgen::Transpiled {

--- a/crates/js-component-bindgen/Cargo.toml
+++ b/crates/js-component-bindgen/Cargo.toml
@@ -9,6 +9,9 @@ edition.workspace = true
 [lib]
 crate-type = ["lib"]
 
+[features]
+raw-bindgen = []
+
 [dependencies]
 anyhow = { workspace = true }
 heck = { workspace = true }

--- a/crates/js-component-bindgen/src/bindgen.rs
+++ b/crates/js-component-bindgen/src/bindgen.rs
@@ -42,6 +42,7 @@ pub struct GenerationOpts {
     pub valid_lifting_optimization: bool,
     /// Provide raw function and interface bindgen only, without
     /// handling initialization, imports or exports
+    #[cfg(feature = "raw-bindgen")]
     pub raw_bindgen: bool,
 }
 

--- a/crates/js-component-bindgen/src/bindgen.rs
+++ b/crates/js-component-bindgen/src/bindgen.rs
@@ -40,6 +40,9 @@ pub struct GenerationOpts {
     /// Disable verification of component Wasm data structures when
     /// lifting as a production optimization
     pub valid_lifting_optimization: bool,
+    /// Provide raw function and interface bindgen only, without
+    /// handling initialization, imports or exports
+    pub raw_bindgen: bool,
 }
 
 impl GenerationOpts {
@@ -48,6 +51,10 @@ impl GenerationOpts {
         gen.opts = self;
         if gen.opts.compat {
             gen.opts.tla_compat = true;
+        }
+        if gen.opts.raw_bindgen {
+            gen.opts.no_typescript = true;
+            gen.opts.tla_compat = false;
         }
         Ok(gen)
     }
@@ -306,6 +313,9 @@ impl JsBindgen {
                 &self.src.js_init as &str,
                 &self.src.js as &str,
             );
+        } else if self.opts.raw_bindgen {
+            output.push_str(&self.src.js_intrinsics);
+            output.push_str(&self.src.js);
         } else {
             // Import statements render first in JS instance mode
             for (specifier, bindings) in &self.imports {
@@ -1100,7 +1110,7 @@ impl Instantiator<'_> {
             imports_vec.push((id, callee.clone()));
         }
 
-        uwrite!(self.src.js_init, "\nfunction lowering{index}");
+        uwrite!(self.src.js, "\nfunction lowering{index}");
         let nparams = self
             .resolve
             .wasm_signature(AbiVariant::GuestImport, func)
@@ -1118,8 +1128,8 @@ impl Instantiator<'_> {
         assert!(latest.ts.is_empty());
         assert!(latest.js_init.is_empty());
         self.src.js_intrinsics(&latest.js_intrinsics);
-        self.src.js_init(&latest.js);
-        uwriteln!(self.src.js_init, "");
+        self.src.js(&latest.js);
+        uwriteln!(self.src.js, "");
     }
 
     fn bindgen(
@@ -1250,6 +1260,7 @@ impl Instantiator<'_> {
             uwriteln!(self.src.js, "{{");
         }
 
+        let mut camel_exports = Vec::new();
         for (name, export) in exports {
             let item = &self.resolve.worlds[self.world].exports[name];
             let camel = name.to_lower_camel_case();
@@ -1278,7 +1289,7 @@ impl Instantiator<'_> {
                     if self.gen.opts.instantiation {
                         uwriteln!(self.src.js, "{camel}: {{");
                     } else {
-                        uwriteln!(self.src.js, "export const {camel} = {{");
+                        uwriteln!(self.src.js, "const {camel} = {{");
                     }
                     for (func_name, export) in exports {
                         let (func, options) = match export {
@@ -1308,9 +1319,12 @@ impl Instantiator<'_> {
                 // This can't be tested at this time so leave it unimplemented
                 Export::Module(_) => unimplemented!(),
             }
+            camel_exports.push(camel);
         }
         if self.gen.opts.instantiation {
             self.src.js("}");
+        } else if !self.gen.opts.raw_bindgen {
+            uwriteln!(self.src.js, "\nexport {{ {} }}", camel_exports.join(", "));
         }
     }
 
@@ -1326,7 +1340,7 @@ impl Instantiator<'_> {
         if self.gen.opts.instantiation || instance_name.is_some() {
             self.src.js.push_str(&name);
         } else {
-            uwrite!(self.src.js, "\nexport function {name}");
+            uwrite!(self.src.js, "\nfunction {name}");
         }
         let callee = self.core_def(def);
         self.bindgen(

--- a/test/cli.js
+++ b/test/cli.js
@@ -23,7 +23,7 @@ export async function cliTest (fixtures) {
         const { stderr } = await exec(jsctPath, 'transpile', `test/fixtures/${name}.component.wasm`, '--name', name, '-o', outDir);
         strictEqual(stderr, '');
         const source = await readFile(`${outDir}/${name}.js`);
-        ok(source.toString().includes('export function thunk'));
+        ok(source.toString().includes('export { thunk'));
       }
       finally {
         await cleanup();
@@ -36,7 +36,7 @@ export async function cliTest (fixtures) {
         const { stderr } = await exec(jsctPath, 'transpile', `test/fixtures/${name}.component.wasm`, '--name', name, '--valid-lifting-optimization', '--tla-compat', '--optimize', '--minify', '--base64-cutoff=0', '-o', outDir);
         strictEqual(stderr, '');
         const source = await readFile(`${outDir}/${name}.js`);
-        ok(source.toString().includes('export function thunk'));
+        ok(source.toString().includes('as thunk}'));
       }
       finally {
         await cleanup();


### PR DESCRIPTION
This adds a new `raw_bindgen` generation option, along with flattening the generation output so that import functions are declared flat as opposed to within the initialization closure.

This option disables the imports, exports and initialization, effectively exposing a contract of:

* Imports must define functions `lowering{idx}Callee`
* Lowered imports can be referenced via `lowering{idx}`
* `memory{idx}`, `realloc{idx}`, `exports{idx}` are defined variables, but must be set externally
* Exported interfaces are provided by their exact names

Intrinsics are still output exactly, modular / separated intrinsics could be further looked into as a possible future feature.

The above bindgen with some well-defined wrapping enables more flexible embedding scenarios. I think this embedding use case is important and it's somewhat similar to the custom instantiation output except that there is no instantiation actually happening in this use case of dummy world operation, as it's a direct singular binding mapping. I'm not sure how to better categorise this use case though, to further distinguish the above defined contract, suggestions very much welcome too.