### PR TITLE
feat: wasm-tools component embed support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,8 @@ name = "wasm-tools-js"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.97.0",
+ "wasm-encoder 0.22.0",
+ "wasmparser 0.99.0",
  "wasmprinter",
  "wat",
  "wit-bindgen-guest-rust",
@@ -546,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.98.1"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8724c724dc595495979c055f4bd8b7ed9fab1069623178a28016ae43a9666f36"
+checksum = "9ef3b717afc67f848f412d4f02c127dd3e35a0eecd58c684580414df4fde01d3"
 dependencies = [
  "indexmap",
  "url",
@@ -556,12 +557,12 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.48"
+version = "0.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322949f382cd5e4bad4330e144bf2124b3182846194ac01e2423c07a6a15ba85"
+checksum = "27c13dff901f9354fa9a6a877152d9c5642513645985635c9b83bcca99e40ea1"
 dependencies = [
  "anyhow",
- "wasmparser 0.98.1",
+ "wasmparser 0.99.0",
 ]
 
 [[package]]
@@ -603,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "52.0.1"
+version = "52.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829fb867c8e82d21557a2c6c5b3ed8e8f7cdd534ea782b9ecf68bede5607fe4b"
+checksum = "707a9fd59b0144c530f0a31f21737036ffea6ece492918cae0843dd09b6f9bc9"
 dependencies = [
  "leb128",
  "memchr",
@@ -615,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3493e7c82d8e9a75e69ecbfe6f324ca1c4e2ae89f67ccbb22f92282e2e27bb23"
+checksum = "91d73cbaa81acc2f8a3303e2289205c971d99c89245c2f56ab8765c4daabc2be"
 dependencies = [
  "wast",
 ]
@@ -707,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1781394df3f08797267cb455bac2b67cd13051d16279bd93e6c63d632c98e1"
+checksum = "be202ba9a64b6c9531bcb3503b03333a6a75b9b0e12e623e4509887c02298b79"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -717,15 +718,16 @@ dependencies = [
  "log",
  "url",
  "wasm-encoder 0.22.0",
- "wasmparser 0.98.1",
+ "wasmparser 0.99.0",
+ "wat",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cfa79275011530f37e0e164183c606bae1cdc466ea90bcd364d50605486a4d"
+checksum = "2e60c4242d4cf4394fac7587c0d96c39b3c0fb09e638815c3f244f6bb5356f04"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ env_logger = "0.9.1"
 indexmap = "1.9"
 wasmtime = { git = 'https://github.com/bytecodealliance/wasmtime', features = ["component-model"] }
 wasmtime-environ = { git = 'https://github.com/bytecodealliance/wasmtime' }
-wasmprinter = "0.2.46"
-wasmparser = "0.97.0"
-wasm-encoder = "0.21.0"
-wat = "1.0.53"
+wasmprinter = "0.2.49"
+wasmparser = "0.99.0"
+wasm-encoder = "0.22.0"
+wat = "1.0.56"
 wit-bindgen-guest-rust = { git = 'https://github.com/bytecodealliance/wit-bindgen', default-features = false, features = ['macros'] }
-wit-component = "0.4.1"
-wit-parser = "0.4.0"
+wit-component = { version = "0.4.3", features = ['dummy-module'] }
+wit-parser = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -64,21 +64,25 @@ Transpile a Component to JS.
 
 Optimize a Component with the [Binaryen Wasm-opt](https://www.npmjs.com/package/binaryen) project.
 
-#### `parse(wat: string): Uint8Array`
+#### `componentWit(component: Uint8Array, document?: string): string`
 
-Parse a compoment WAT to output a Component binary.
+Extract the WIT world from a component binary.
 
 #### `print(component: Uint8Array): string`
 
 Print the WAT for a Component binary.
 
+#### `parse(wat: string): Uint8Array`
+
+Parse a compoment WAT to output a Component binary.
+
 #### `componentNew(coreWasm: Uint8Array | null, adapters?: [String, Uint8Array][]): Uint8Array`
 
 "WIT Component" Component creation tool, optionally providing a set of named adapter binaries.
 
-#### `componentWit(component: Uint8Array, document?: string): string`
+#### `componentEmbed(coreWasm: Uint8Array | null, wit: String, opts?: { stringEncoding?, dummy?, world? }): Uint8Array`
 
-Extract the WIT world from a component binary.
+"WIT Component" Component embedding tool, for embedding component types into core binaries, as an advanced use case of component generation.
 
 ## CLI
 
@@ -98,7 +102,8 @@ Commands:
   wit [options] <component-path>        extract the WIT from a WebAssembly Component [wasm-tools component wit]
   print [options] <input>               print the WebAssembly WAT text for a binary file [wasm-tools print]
   parse [options] <input>               parses the Wasm text format into a binary file [wasm-tools parse]
-  new [options] [module]                create a WebAssembly component adapted from a component core Wasm [wasm-tools component new]
+  new [options] <core-module>           create a WebAssembly component adapted from a component core Wasm [wasm-tools component new]
+  embed [options] [core-module]         embed the component typing section into a core Wasm module [wasm-tools component embed]
   help [command]                        display help for command
 ```
 

--- a/api.d.ts
+++ b/api.d.ts
@@ -58,6 +58,15 @@ export function print(binary: Uint8Array | ArrayBuffer): string;
 export function componentNew(binary: Uint8Array | ArrayBuffer, adapters?: [string, Uint8Array][] | null): Uint8Array;
 
 /**
+ * Embed a world into a Wasm core binary
+ */
+export function componentEmbed(binary: Uint8Array | ArrayBuffer | null, wit: string, opts: {
+  stringEncoding?: 'utf8' | 'utf16' | 'compact-utf16',
+  dummy?: boolean,
+  world?: string,
+}): Uint8Array;
+
+/**
  * Extract the WIT world from a Wasm Component
  */
 export function componentWit(binary: Uint8Array | ArrayBuffer, document?: string | null): string;

--- a/crates/wasm-tools-component/Cargo.toml
+++ b/crates/wasm-tools-component/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 anyhow = { workspace = true }
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
+wasm-encoder = { workspace = true }
 wat = { workspace = true }
 wit-bindgen-guest-rust = { workspace = true, features = ['default'] }
 wit-component = { workspace = true }

--- a/crates/wasm-tools-component/src/lib.rs
+++ b/crates/wasm-tools-component/src/lib.rs
@@ -1,6 +1,8 @@
-use std::sync::Once;
+use std::{path::PathBuf, sync::Once};
+use wasm_encoder::{Encode, Section};
 use wasmparser;
-use wit_component::{ComponentEncoder, DecodedWasm, DocumentPrinter};
+use wit_component::{ComponentEncoder, DecodedWasm, DocumentPrinter, StringEncoding};
+use wit_parser::{Resolve, UnresolvedPackage};
 
 wit_bindgen_guest_rust::generate!("wasm-tools");
 
@@ -20,16 +22,16 @@ fn init() {
 }
 
 impl exports::Exports for WasmToolsJs {
-    fn print(component: Vec<u8>) -> Result<String, String> {
-        init();
-
-        wasmprinter::print_bytes(component).map_err(|e| format!("{:?}", e))
-    }
-
     fn parse(wat: String) -> Result<Vec<u8>, String> {
         init();
 
         wat::parse_str(wat).map_err(|e| format!("{:?}", e))
+    }
+
+    fn print(component: Vec<u8>) -> Result<String, String> {
+        init();
+
+        wasmprinter::print_bytes(component).map_err(|e| format!("{:?}", e))
     }
 
     fn component_new(
@@ -75,6 +77,94 @@ impl exports::Exports for WasmToolsJs {
             .print(decoded.resolve(), doc)
             .map_err(|e| format!("Unable to print wit\n${:?}", e))?;
         Ok(output)
+    }
+
+    fn component_embed(
+        binary: Option<Vec<u8>>,
+        wit: String,
+        opts: Option<exports::EmbedOpts>,
+    ) -> Result<Vec<u8>, String> {
+        let mut resolve = Resolve::default();
+
+        let path = PathBuf::from("component.wit");
+
+        let pkg = UnresolvedPackage::parse(&path, &wit).map_err(|e| e.to_string())?;
+
+        let id = resolve
+            .push(pkg, &Default::default())
+            .map_err(|e| e.to_string())?;
+
+        let world = if let Some(exports::EmbedOpts {
+            world: Some(ref world),
+            ..
+        }) = opts
+        {
+            let mut parts = world.split('/');
+            let doc = match parts.next() {
+                Some(name) => match resolve.packages[id].documents.get(name) {
+                    Some(doc) => *doc,
+                    None => return Err("no document named `{name}` in package".to_string()),
+                },
+                None => return Err("invalid `world` argument".to_string()),
+            };
+            match parts.next() {
+                Some(name) => match resolve.documents[doc].worlds.get(name) {
+                    Some(world) => *world,
+                    None => return Err(format!("no world named `{name}` in document")),
+                },
+                None => match resolve.documents[doc].default_world {
+                    Some(world) => world,
+                    None => return Err("no default world found in document".to_string()),
+                },
+            }
+        } else {
+            let docs = &resolve.packages[id];
+            let (_, doc) = docs.documents.first().unwrap();
+            match resolve.documents[*doc].default_world {
+                Some(world) => world,
+                None => return Err("no default world found in document".into()),
+            }
+        };
+
+        let string_encoding = match opts {
+            Some(ref opts) => match &opts.string_encoding {
+                None | Some(exports::StringEncoding::Utf8) => StringEncoding::UTF8,
+                Some(exports::StringEncoding::Utf16) => StringEncoding::UTF16,
+                Some(exports::StringEncoding::CompactUtf16) => StringEncoding::CompactUTF16,
+            },
+            None => StringEncoding::UTF8,
+        };
+
+        let mut core_binary = if matches!(
+            opts,
+            Some(exports::EmbedOpts {
+                dummy: Some(true),
+                ..
+            })
+        ) {
+            wit_component::dummy_module(&resolve, world)
+        } else {
+            if binary.is_none() {
+                return Err(
+                    "no core binary provided. Use the `dummy` option to generate an empty binary."
+                        .to_string(),
+                );
+            }
+            binary.unwrap()
+        };
+
+        let encoded = wit_component::metadata::encode(&resolve, world, string_encoding)
+            .map_err(|e| e.to_string())?;
+
+        let section = wasm_encoder::CustomSection {
+            name: "component-type",
+            data: &encoded,
+        };
+
+        core_binary.push(section.id());
+        section.encode(&mut core_binary);
+
+        Ok(core_binary)
     }
 
     fn extract_core_modules(binary: Vec<u8>) -> Result<Vec<(u32, u32)>, String> {

--- a/crates/wasm-tools-component/wit/wasm-tools.wit
+++ b/crates/wasm-tools-component/wit/wasm-tools.wit
@@ -14,11 +14,20 @@ default world wasm-tools-js {
       compact-utf16
     }
 
-    /// Create a component from a core wasm binary
+    /// Create a component from a core wasm binary that implements and embeds a component type
     component-new: func(binary: list<u8>, adapters: option<list<tuple<string, list<u8>>>>) -> result<list<u8>, string>
 
     /// Extract a *.wit interface from a component, optionally providing a document name to extract
     component-wit: func(binary: list<u8>, document: option<string>) -> result<string, string>
+
+    /// Embed a WIT type into a component.
+    /// Only a singular WIT document without use resolutions is supported for this API.
+    record embed-opts {
+      string-encoding: option<string-encoding>,
+      dummy: option<bool>,
+      %world: option<string>,
+    }
+    component-embed: func(binary: option<list<u8>>, wit: string, opts: option<embed-opts>) -> result<list<u8>, string>
 
     /// Extract the core modules from a component
     /// (strictly speaking this makes it Wasm Tools + Extract Core Modules)

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
 export { optimizeComponent as opt } from './cmd/opt.js';
 export { transpileComponent as transpile } from './cmd/transpile.js';
 import { exports } from '../obj/wasm-tools.js';
-export const { parse, print, componentNew, componentWit } = exports;
+export const { parse, print, componentNew, componentWit, componentEmbed } = exports;

--- a/src/cmd/opt.js
+++ b/src/cmd/opt.js
@@ -1,8 +1,8 @@
 import { exports } from '../../obj/wasm-tools.js';
-import { readFile, writeFile } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import { fileURLToPath } from 'url';
 import c from 'chalk-template';
-import { sizeStr, fixedDigitDisplay, table, spawnIOTmp, setShowSpinner, getShowSpinner } from '../common.js';
+import { readFile, sizeStr, fixedDigitDisplay, table, spawnIOTmp, setShowSpinner, getShowSpinner } from '../common.js';
 import ora from 'ora';
 
 const { extractCoreModules, print } = exports;

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -1,9 +1,9 @@
 import { exports } from '../../obj/js-component-bindgen-component.js';
-import { readFile, writeFile } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import { mkdir } from 'fs/promises';
 import { dirname, extname, basename } from 'path';
 import c from 'chalk-template';
-import { sizeStr, table, spawnIOTmp, setShowSpinner, getShowSpinner } from '../common.js';
+import { readFile, sizeStr, table, spawnIOTmp, setShowSpinner, getShowSpinner } from '../common.js';
 import { optimizeComponent } from './opt.js';
 import { minify } from 'terser';
 import { fileURLToPath } from 'url';

--- a/src/cmd/wasm-tools.js
+++ b/src/cmd/wasm-tools.js
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
+import { readFile } from '../common.js';
 import { exports } from "../../obj/wasm-tools.js";
 import { basename, extname } from 'node:path';
 
@@ -6,7 +7,8 @@ const {
   print: printFn,
   parse: parseFn,
   componentWit: componentWitFn,
-  componentNew: componentNewFn
+  componentNew: componentNewFn,
+  componentEmbed: componentEmbedFn,
 } = exports;
 
 export async function parse(file, opts) {
@@ -49,5 +51,12 @@ export async function componentNew(file, opts) {
       return adapter;
     }));
   const output = componentNewFn(source, adapters);
+  await writeFile(opts.output, output);
+}
+
+export async function componentEmbed(file, opts) {  
+  const source = file ? await readFile(file) : null;
+  const wit = await readFile(opts.wit, 'utf8');
+  const output = componentEmbedFn(source, wit, opts);
   await writeFile(opts.output, output);
 }

--- a/src/common.js
+++ b/src/common.js
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { readFile, writeFile, unlink } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { argv0 } from 'node:process';
+import c from 'chalk-template';
 
 let _showSpinner = false;
 export function setShowSpinner (val) {
@@ -58,6 +59,16 @@ export function table (data, align = []) {
 export function getTmpFile (source, ext) {
   return resolve(tmpdir(), crypto.createHash('sha256').update(source).update(Math.random().toString()).digest('hex') + ext);
 }
+
+async function readFileCli (file, encoding) {
+  try {
+    return await readFile(file, encoding)
+  }
+  catch (e) {
+    throw c`Unable to read file {bold ${file}}`;
+  }
+}
+export { readFileCli as readFile }
 
 export async function spawnIOTmp (cmd, input, args) {
   const inFile = getTmpFile(input, '.wasm');

--- a/src/jsct.js
+++ b/src/jsct.js
@@ -2,7 +2,7 @@
 import { program } from 'commander';
 import { opt } from './cmd/opt.js';
 import { transpile } from './cmd/transpile.js';
-import { parse, print, componentNew, componentWit } from './cmd/wasm-tools.js';
+import { parse, print, componentNew, componentEmbed, componentWit } from './cmd/wasm-tools.js';
 import c from 'chalk-template';
 
 program
@@ -66,11 +66,21 @@ program.command('parse')
 
 program.command('new')
   .description('create a WebAssembly component adapted from a component core Wasm [wasm-tools component new]')
-  .argument('[core-module]', 'Wasm core module filepath')
+  .argument('<core-module>', 'Wasm core module filepath')
   .requiredOption('-o, --output <output-file>', 'Wasm component output filepath')
   .option('--name <name>', 'custom output name')
   .option('--adapt <[NAME=]adapter...>', 'component adapters to apply')
   .action(asyncAction(componentNew));
+
+program.command('embed')
+  .description('embed the component typing section into a core Wasm module [wasm-tools component embed]')
+  .argument('[core-module]', 'Wasm core module filepath')
+  .requiredOption('-o, --output <output-file>', 'Wasm component output filepath')
+  .requiredOption('--wit <wit-world>', 'WIT world path')
+  .option('--dummy', 'generate a dummy component')
+  .option('--string-encoding <utf8|utf16|compact-utf16>', 'set the component string encoding')
+  .option('--world <world-name>', 'positional world path to embed')
+  .action(asyncAction(componentEmbed));
 
 program.parse();
 

--- a/test/api.js
+++ b/test/api.js
@@ -1,6 +1,6 @@
 import { deepStrictEqual, ok, strictEqual } from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import { transpile, opt, print, parse, componentWit, componentNew } from 'js-component-tools';
+import { transpile, opt, print, parse, componentWit, componentNew, componentEmbed } from '../src/api.js';
 
 export async function apiTest (fixtures) {
   suite('API', () => {
@@ -76,10 +76,9 @@ export async function apiTest (fixtures) {
       const wit = await componentWit(component);
       strictEqual(wit.slice(0, 25), 'default world component {');
 
-      // TODO: reenable when dummy is supported
-      // const generatedComponent = await componentNew(null, { wit });
-      // const output = await print(generatedComponent);
-      // strictEqual(output.slice(0, 10), '(component');
+      const generatedComponent = await componentEmbed(null, wit, { dummy: true });
+      const output = await print(generatedComponent);
+      strictEqual(output.slice(0, 10), '(component');
     });
 
     test('Component new adapt', async () => {

--- a/test/api.js
+++ b/test/api.js
@@ -77,8 +77,16 @@ export async function apiTest (fixtures) {
       strictEqual(wit.slice(0, 25), 'default world component {');
 
       const generatedComponent = await componentEmbed(null, wit, { dummy: true });
-      const output = await print(generatedComponent);
-      strictEqual(output.slice(0, 10), '(component');
+      {
+        const output = await print(generatedComponent);
+        strictEqual(output.slice(0, 7), '(module');
+      }
+
+      const newComponent = await componentNew(generatedComponent);
+      {
+        const output = await print(newComponent);
+        strictEqual(output.slice(0, 10), '(component');
+      }
     });
 
     test('Component new adapt', async () => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -116,6 +116,18 @@ export async function cliTest (fixtures) {
         {
           const { stderr, stdout } = await exec(jsctPath, 'print', outFile);
           strictEqual(stderr, '');
+          strictEqual(stdout.slice(0, 7), '(module');
+        }
+
+        {
+          const { stderr, stdout } = await exec(jsctPath, 'new', outFile, '-o', outFile);
+          strictEqual(stderr, '');
+          strictEqual(stdout, '');
+        }
+
+        {
+          const { stderr, stdout } = await exec(jsctPath, 'print', outFile);
+          strictEqual(stderr, '');
           strictEqual(stdout.slice(0, 10), '(component');
         }
       }

--- a/test/cli.js
+++ b/test/cli.js
@@ -107,18 +107,17 @@ export async function cliTest (fixtures) {
           strictEqual(stdout, '');
         }
 
-        // TODO: reenable for dummy generation
-        // {
-        //   const { stderr, stdout } = await exec(jsctPath, 'new', '--types-only', '--wit', outFile, '-o', outFile);
-        //   strictEqual(stderr, '');
-        //   strictEqual(stdout, '');
-        // }
+        {
+          const { stderr, stdout } = await exec(jsctPath, 'embed', '--dummy', '--wit', outFile, '-o', outFile);
+          strictEqual(stderr, '');
+          strictEqual(stdout, '');
+        }
 
-        // {
-        //   const { stderr, stdout } = await exec(jsctPath, 'print', outFile);
-        //   strictEqual(stderr, '');
-        //   strictEqual(stdout.slice(0, 10), '(component');
-        // }
+        {
+          const { stderr, stdout } = await exec(jsctPath, 'print', outFile);
+          strictEqual(stderr, '');
+          strictEqual(stdout.slice(0, 10), '(component');
+        }
       }
       finally {
         await cleanup();


### PR DESCRIPTION
This adds support for the `wasm-tools component embed` command which is the new way to embed world information into component binaries now that it has been separated from the `wasm-tools component new` command.

This enables the former component new use cases within the JS toolchain and also updates Cargo dependencies.