### PR TITLE
feat: producer metadata tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.24.0",
+ "wasm-metadata",
  "wasmparser 0.101.0",
  "wasmprinter",
  "wat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,17 @@ version = "0.1.0"
 anyhow = "1.0.65"
 base64 = "0.13.1"
 bitflags = "1.3.2"
-heck =  { version = "0.4", features = ["unicode"] }
-pulldown-cmark = { version = "0.8", default-features = false }
 clap = { version = "4.0.9", features = ["derive"] }
 env_logger = "0.9.1"
+heck =  { version = "0.4", features = ["unicode"] }
 indexmap = "1.9"
+pulldown-cmark = { version = "0.8", default-features = false }
+wasm-encoder = "0.24.0"
+wasm-metadata = "0.2.0"
+wasmparser = "0.101.0"
+wasmprinter = "0.2.51"
 wasmtime = { git = 'https://github.com/bytecodealliance/wasmtime', features = ["component-model"] }
 wasmtime-environ = { git = 'https://github.com/bytecodealliance/wasmtime' }
-wasmprinter = "0.2.51"
-wasmparser = "0.101.0"
-wasm-encoder = "0.24.0"
 wat = "1.0.59"
 wit-bindgen-guest-rust = { git = 'https://github.com/bytecodealliance/wit-bindgen', default-features = false, features = ['macros'] }
 wit-component = { version = "0.7.0", features = ['dummy-module'] }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Extract the WIT world from a component binary.
 
 Print the WAT for a Component binary.
 
-#### `metadata(wasm: Uint8Array): Metadata`
+#### `metadataShow(wasm: Uint8Array): Metadata`
 
 Extract the producer toolchain metadata for a component and its nested modules.
 
@@ -87,6 +87,10 @@ Parse a compoment WAT to output a Component binary.
 #### `componentEmbed(coreWasm: Uint8Array | null, wit: String, opts?: { stringEncoding?, dummy?, world?, metadata? }): Uint8Array`
 
 "WIT Component" Component embedding tool, for embedding component types into core binaries, as an advanced use case of component generation.
+
+#### `metadataAdd(wasm: Uint8Array, metadata): Uint8Array`
+
+Add new producer metadata to a component or core Wasm binary.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Extract the WIT world from a component binary.
 
 Print the WAT for a Component binary.
 
+#### `metadata(wasm: Uint8Array): Metadata`
+
+Extract the producer toolchain metadata for a component and its nested modules.
+
 #### `parse(wat: string): Uint8Array`
 
 Parse a compoment WAT to output a Component binary.
@@ -80,7 +84,7 @@ Parse a compoment WAT to output a Component binary.
 
 "WIT Component" Component creation tool, optionally providing a set of named adapter binaries.
 
-#### `componentEmbed(coreWasm: Uint8Array | null, wit: String, opts?: { stringEncoding?, dummy?, world? }): Uint8Array`
+#### `componentEmbed(coreWasm: Uint8Array | null, wit: String, opts?: { stringEncoding?, dummy?, world?, metadata? }): Uint8Array`
 
 "WIT Component" Component embedding tool, for embedding component types into core binaries, as an advanced use case of component generation.
 
@@ -101,6 +105,7 @@ Commands:
   opt [options] <component-file>        optimizes a Wasm component, including running wasm-opt Binaryen optimizations
   wit [options] <component-path>        extract the WIT from a WebAssembly Component [wasm-tools component wit]
   print [options] <input>               print the WebAssembly WAT text for a binary file [wasm-tools print]
+  metadata [options] [module]           extract the producer metadata for a Wasm binary [wasm-tools metadata show]
   parse [options] <input>               parses the Wasm text format into a binary file [wasm-tools parse]
   new [options] <core-module>           create a WebAssembly component adapted from a component core Wasm [wasm-tools component new]
   embed [options] [core-module]         embed the component typing section into a core Wasm module [wasm-tools component embed]

--- a/api.d.ts
+++ b/api.d.ts
@@ -57,6 +57,8 @@ export function print(binary: Uint8Array | ArrayBuffer): string;
  */
 export function componentNew(binary: Uint8Array | ArrayBuffer, adapters?: [string, Uint8Array][] | null): Uint8Array;
 
+type Metadata = [string, [string, string][]][];
+
 /**
  * Embed a world into a Wasm core binary
  */
@@ -64,7 +66,17 @@ export function componentEmbed(binary: Uint8Array | ArrayBuffer | null, wit: str
   stringEncoding?: 'utf8' | 'utf16' | 'compact-utf16',
   dummy?: boolean,
   world?: string,
+  metadata?: Metadata
 }): Uint8Array;
+
+/**
+ * Extract the producer metadata for a Wasm component or core module
+ */
+export function metadata(binary: Uint8Array | ArrayBuffer): {
+  name?: string,
+  metaType: { tag: 'module' } | { tag: 'component', val: number },
+  metadata: Metadata
+}[];
 
 /**
  * Extract the WIT world from a Wasm Component

--- a/api.d.ts
+++ b/api.d.ts
@@ -72,11 +72,16 @@ export function componentEmbed(binary: Uint8Array | ArrayBuffer | null, wit: str
 /**
  * Extract the producer metadata for a Wasm component or core module
  */
-export function metadata(binary: Uint8Array | ArrayBuffer): {
+export function metadataShow(binary: Uint8Array | ArrayBuffer): {
   name?: string,
   metaType: { tag: 'module' } | { tag: 'component', val: number },
   metadata: Metadata
 }[];
+
+/**
+ * Extract the producer metadata for a Wasm component or core module
+ */
+export function metadataAdd(binary: Uint8Array | ArrayBuffer, metadata: Metadata): Uint8Array;
 
 /**
  * Extract the WIT world from a Wasm Component

--- a/crates/wasm-tools-component/Cargo.toml
+++ b/crates/wasm-tools-component/Cargo.toml
@@ -11,9 +11,10 @@ doctest = false
 
 [dependencies]
 anyhow = { workspace = true }
+wasm-encoder = { workspace = true }
+wasm-metadata = { workspace = true }
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
-wasm-encoder = { workspace = true }
 wat = { workspace = true }
 wit-bindgen-guest-rust = { workspace = true, features = ['default'] }
 wit-component = { workspace = true }

--- a/crates/wasm-tools-component/src/lib.rs
+++ b/crates/wasm-tools-component/src/lib.rs
@@ -1,5 +1,7 @@
+use std::collections::VecDeque;
 use std::{path::PathBuf, sync::Once};
 use wasm_encoder::{Encode, Section};
+use wasm_metadata::Producers;
 use wasmparser;
 use wit_component::{ComponentEncoder, DecodedWasm, DocumentPrinter, StringEncoding};
 use wit_parser::{Resolve, UnresolvedPackage};
@@ -9,6 +11,8 @@ wit_bindgen_guest_rust::generate!("wasm-tools");
 struct WasmToolsJs;
 
 export_wasm_tools_js!(WasmToolsJs);
+
+use crate::exports::*;
 
 fn init() {
     static INIT: Once = Once::new();
@@ -165,7 +169,83 @@ impl exports::Exports for WasmToolsJs {
         core_binary.push(section.id());
         section.encode(&mut core_binary);
 
+        let mut producer_section = wasm_encoder::ProducersSection::new();
+
+        match opts {
+            Some(ref opts) => match &opts.metadata {
+                Some(metadata_fields) => {
+                    for (field_name, items) in metadata_fields {
+                        if field_name != "sdk"
+                            && field_name != "language"
+                            && field_name != "processed-by"
+                        {
+                            return Err(format!("'{field_name}' is not a valid field to embed in the metadata. Must be one of 'language', 'processed-by' or 'sdk'."));
+                        }
+                        let mut field = wasm_encoder::ProducersField::new();
+                        for (name, version) in items {
+                            field.value(&name, &version);
+                        }
+                        producer_section.field(&field_name, &field);
+                    }
+                }
+                None => {}
+            },
+            None => {}
+        };
+
+        core_binary.push(producer_section.id());
+        producer_section.encode(&mut core_binary);
+
         Ok(core_binary)
+    }
+
+    fn metadata(binary: Vec<u8>) -> Result<Vec<ModuleMetadata>, String> {
+        let metadata =
+            wasm_metadata::Metadata::from_binary(&binary).map_err(|e| format!("{:?}", e))?;
+        let mut module_metadata: Vec<ModuleMetadata> = Vec::new();
+        let mut to_flatten: VecDeque<wasm_metadata::Metadata> = VecDeque::new();
+        to_flatten.push_back(metadata);
+        while let Some(metadata) = to_flatten.pop_front() {
+            let (name, producers, meta_type) = match metadata {
+                wasm_metadata::Metadata::Component {
+                    name,
+                    producers,
+                    children,
+                } => {
+                    let children_len = children.len();
+                    for child in children {
+                        to_flatten.push_back(*child);
+                    }
+                    (
+                        name,
+                        producers,
+                        ModuleMetaType::Component(children_len as u32),
+                    )
+                }
+                wasm_metadata::Metadata::Module { name, producers } => {
+                    (name, producers, ModuleMetaType::Module)
+                }
+            };
+
+            let mut metadata: Vec<(String, Vec<(String, String)>)> = Vec::new();
+            if let Some(producers) = producers {
+                for (key, fields) in producers.iter() {
+                    metadata.push((
+                        key.to_string(),
+                        fields
+                            .iter()
+                            .map(|(value, version)| (value.to_string(), version.to_string()))
+                            .collect(),
+                    ));
+                }
+            }
+            module_metadata.push(ModuleMetadata {
+                name,
+                meta_type,
+                metadata,
+            });
+        }
+        Ok(module_metadata)
     }
 
     fn extract_core_modules(binary: Vec<u8>) -> Result<Vec<(u32, u32)>, String> {

--- a/crates/wasm-tools-component/src/lib.rs
+++ b/crates/wasm-tools-component/src/lib.rs
@@ -158,10 +158,10 @@ impl exports::Exports for WasmToolsJs {
             binary.unwrap()
         };
 
-        let mut producers = Producers::default();
-        match opts {
+        let producers = match opts {
             Some(ref opts) => match &opts.metadata {
                 Some(metadata_fields) => {
+                    let mut producers = Producers::default();
                     for (field_name, items) in metadata_fields {
                         if field_name != "sdk"
                             && field_name != "language"
@@ -173,14 +173,16 @@ impl exports::Exports for WasmToolsJs {
                             producers.add(&field_name, &name, &version);
                         }
                     }
+                    Some(producers)
                 }
-                None => {}
+                None => None,
             },
-            None => {}
+            None => None,
         };
 
-        let encoded = wit_component::metadata::encode(&resolve, world, string_encoding, None)
-            .map_err(|e| e.to_string())?;
+        let encoded =
+            wit_component::metadata::encode(&resolve, world, string_encoding, producers.as_ref())
+                .map_err(|e| e.to_string())?;
 
         let section = wasm_encoder::CustomSection {
             name: "component-type",

--- a/crates/wasm-tools-component/wit/wasm-tools.wit
+++ b/crates/wasm-tools-component/wit/wasm-tools.wit
@@ -20,7 +20,7 @@ default world wasm-tools-js {
     /// Extract a *.wit interface from a component, optionally providing a document name to extract
     component-wit: func(binary: list<u8>, document: option<string>) -> result<string, string>
 
-    type metadata-fields = list<tuple<string, list<tuple<string, string>>>>
+    type producers-fields = list<tuple<string, list<tuple<string, string>>>>
 
     /// Embed a WIT type into a component.
     /// Only a singular WIT document without use resolutions is supported for this API.
@@ -28,7 +28,7 @@ default world wasm-tools-js {
       string-encoding: option<string-encoding>,
       dummy: option<bool>,
       %world: option<string>,
-      metadata: option<metadata-fields>
+      metadata: option<producers-fields>
     }
 
     component-embed: func(binary: option<list<u8>>, wit: string, opts: option<embed-opts>) -> result<list<u8>, string>
@@ -42,11 +42,14 @@ default world wasm-tools-js {
     record module-metadata {
       name: option<string>,
       meta-type: module-meta-type,
-      metadata: metadata-fields,
+      producers: producers-fields,
     }
 
     /// Extract the metadata for a component
-    metadata: func(binary: list<u8>) -> result<list<module-metadata>, string>
+    metadata-show: func(binary: list<u8>) -> result<list<module-metadata>, string>
+
+    /// Append producer metadata to a component
+    metadata-add: func(binary: list<u8>, metadata: producers-fields) -> result<list<u8>, string>
 
     /// Extract the core modules from a component
     /// (strictly speaking this makes it Wasm Tools + Extract Core Modules)

--- a/crates/wasm-tools-component/wit/wasm-tools.wit
+++ b/crates/wasm-tools-component/wit/wasm-tools.wit
@@ -20,14 +20,33 @@ default world wasm-tools-js {
     /// Extract a *.wit interface from a component, optionally providing a document name to extract
     component-wit: func(binary: list<u8>, document: option<string>) -> result<string, string>
 
+    type metadata-fields = list<tuple<string, list<tuple<string, string>>>>
+
     /// Embed a WIT type into a component.
     /// Only a singular WIT document without use resolutions is supported for this API.
     record embed-opts {
       string-encoding: option<string-encoding>,
       dummy: option<bool>,
       %world: option<string>,
+      metadata: option<metadata-fields>
     }
+
     component-embed: func(binary: option<list<u8>>, wit: string, opts: option<embed-opts>) -> result<list<u8>, string>
+
+    variant module-meta-type {
+      module,
+      // the number of nested modules
+      component(u32),
+    }
+
+    record module-metadata {
+      name: option<string>,
+      meta-type: module-meta-type,
+      metadata: metadata-fields,
+    }
+
+    /// Extract the metadata for a component
+    metadata: func(binary: list<u8>) -> result<list<module-metadata>, string>
 
     /// Extract the core modules from a component
     /// (strictly speaking this makes it Wasm Tools + Extract Core Modules)

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
 export { optimizeComponent as opt } from './cmd/opt.js';
 export { transpileComponent as transpile } from './cmd/transpile.js';
 import { exports } from '../obj/wasm-tools.js';
-export const { parse, print, componentNew, componentWit, componentEmbed, metadata } = exports;
+export const { parse, print, componentNew, componentWit, componentEmbed, metadataAdd, metadataShow } = exports;

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
 export { optimizeComponent as opt } from './cmd/opt.js';
 export { transpileComponent as transpile } from './cmd/transpile.js';
 import { exports } from '../obj/wasm-tools.js';
-export const { parse, print, componentNew, componentWit, componentEmbed } = exports;
+export const { parse, print, componentNew, componentWit, componentEmbed, metadata } = exports;

--- a/src/cmd/wasm-tools.js
+++ b/src/cmd/wasm-tools.js
@@ -2,6 +2,7 @@ import { writeFile } from "node:fs/promises";
 import { readFile } from '../common.js';
 import { exports } from "../../obj/wasm-tools.js";
 import { basename, extname } from 'node:path';
+import c from 'chalk-template';
 
 const {
   print: printFn,
@@ -9,6 +10,7 @@ const {
   componentWit: componentWitFn,
   componentNew: componentNewFn,
   componentEmbed: componentEmbedFn,
+  metadata: componentMetadataFn,
 } = exports;
 
 export async function parse(file, opts) {
@@ -54,9 +56,49 @@ export async function componentNew(file, opts) {
   await writeFile(opts.output, output);
 }
 
-export async function componentEmbed(file, opts) {  
+export async function componentEmbed(file, opts) {
+  if (opts.metadata)
+    opts.metadata = opts.metadata.map(meta => {
+      const [field, data = ''] = meta.split('=');
+      const [name, version = ''] = data.split('@');
+      return [field, [[name, version]]];
+    });
   const source = file ? await readFile(file) : null;
   const wit = await readFile(opts.wit, 'utf8');
   const output = componentEmbedFn(source, wit, opts);
   await writeFile(opts.output, output);
+}
+
+export async function componentMetadata(file, opts) {
+  const source = file ? await readFile(file) : null;
+  let output = '', stack = [1];
+  const meta = componentMetadataFn(source);
+  if (opts.json) {
+    console.log(JSON.stringify(meta, null, 2));
+  }
+  else {
+    for (const { name, metaType, metadata } of meta) {
+      output += '  '.repeat(stack.length - 1);
+      const indent = '  '.repeat(stack.length);
+      if (metaType.tag === 'component') {
+        output += c`{bold [component${name ? ' ' + name : ''}]}\n`;
+        if (metaType.val > 0)
+          stack.push(metaType.val);
+      } else {
+        output += c`{bold [module${name ? ' ' + name : ''}]}\n`;
+      }
+      if (metadata.length === 0)
+        output += `${indent}(no metadata)\n`;
+      for (const [field, items] of metadata) {
+        for (const [name, version] of items) {
+          output += `${indent}${(field + ':').padEnd(13, ' ')} ${name}${version ? c`{cyan  ${version}}` : ''}\n`;
+        }
+      }
+      output += '\n';
+      if (stack[stack.length - 1] === 0)
+        stack.pop();
+      stack[stack.length - 1]--;
+    }
+    process.stdout.write(output);
+  }
 }

--- a/src/jsct.js
+++ b/src/jsct.js
@@ -2,7 +2,7 @@
 import { program } from 'commander';
 import { opt } from './cmd/opt.js';
 import { transpile } from './cmd/transpile.js';
-import { parse, print, componentNew, componentEmbed, componentMetadata, componentWit } from './cmd/wasm-tools.js';
+import { parse, print, componentNew, componentEmbed, metadataAdd, metadataShow, componentWit } from './cmd/wasm-tools.js';
 import c from 'chalk-template';
 
 program
@@ -58,11 +58,18 @@ program.command('print')
   .option('-o, --output <output-file>', 'output file path')
   .action(asyncAction(print));
 
-program.command('metadata')
+program.command('metadata-show')
   .description('extract the producer metadata for a Wasm binary [wasm-tools metadata show]')
   .argument('[module]', 'Wasm component or core module filepath')
   .option('--json', 'output component metadata as JSON')
-  .action(asyncAction(componentMetadata));
+  .action(asyncAction(metadataShow));
+
+program.command('metadata-add')
+  .description('add producer metadata for a Wasm binary [wasm-tools metadata add]')
+  .argument('[module]', 'Wasm component or core module filepath')
+  .requiredOption('-m, --metadata <metadata...>', 'field=name[@version] producer metadata to add with the embedding')
+  .requiredOption('-o, --output <output-file>', 'output binary path')
+  .action(asyncAction(metadataAdd));
 
 program.command('parse')
   .description('parses the Wasm text format into a binary file [wasm-tools parse]')

--- a/src/jsct.js
+++ b/src/jsct.js
@@ -2,7 +2,7 @@
 import { program } from 'commander';
 import { opt } from './cmd/opt.js';
 import { transpile } from './cmd/transpile.js';
-import { parse, print, componentNew, componentEmbed, componentWit } from './cmd/wasm-tools.js';
+import { parse, print, componentNew, componentEmbed, componentMetadata, componentWit } from './cmd/wasm-tools.js';
 import c from 'chalk-template';
 
 program
@@ -58,6 +58,12 @@ program.command('print')
   .option('-o, --output <output-file>', 'output file path')
   .action(asyncAction(print));
 
+program.command('metadata')
+  .description('extract the producer metadata for a Wasm binary [wasm-tools metadata show]')
+  .argument('[module]', 'Wasm component or core module filepath')
+  .option('--json', 'output component metadata as JSON')
+  .action(asyncAction(componentMetadata));
+
 program.command('parse')
   .description('parses the Wasm text format into a binary file [wasm-tools parse]')
   .argument('<input>', 'input file to process')
@@ -80,6 +86,7 @@ program.command('embed')
   .option('--dummy', 'generate a dummy component')
   .option('--string-encoding <utf8|utf16|compact-utf16>', 'set the component string encoding')
   .option('--world <world-name>', 'positional world path to embed')
+  .option('-m, --metadata <metadata...>', 'field=name[@version] producer metadata to add with the embedding')
   .action(asyncAction(componentEmbed));
 
 program.parse();

--- a/test/api.js
+++ b/test/api.js
@@ -92,13 +92,12 @@ export async function apiTest (fixtures) {
         strictEqual(output.slice(0, 10), '(component');
       }
 
-      const meta = metadata(newComponent);
+      const meta = metadataShow(newComponent);
       deepStrictEqual(meta[0].metaType, {
         tag: 'component',
         val: 4
       });
-      console.log(JSON.stringify(meta, null, 2));
-      deepStrictEqual(meta[0].producers[0], meta[0])
+      deepStrictEqual(meta[1].producers, [['processed-by', [['wit-component', '0.7.0'], ['dummy-gen', 'test']]], ['language', [['javascript', '']]]])
     });
 
     test('Component new adapt', async () => {

--- a/test/api.js
+++ b/test/api.js
@@ -1,6 +1,6 @@
 import { deepStrictEqual, ok, strictEqual } from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import { transpile, opt, print, parse, componentWit, componentNew, componentEmbed, metadata } from '../src/api.js';
+import { transpile, opt, print, parse, componentWit, componentNew, componentEmbed, metadataShow, metadataAdd } from '../src/api.js';
 
 export async function apiTest (fixtures) {
   suite('API', () => {
@@ -112,7 +112,7 @@ export async function apiTest (fixtures) {
     test('Extract metadata', async () => {
       const component = await readFile(`test/fixtures/exitcode.wasm`);
 
-      const meta = metadata(component);
+      const meta = metadataShow(component);
 
       deepStrictEqual(meta, [{
         metaType: { tag: 'module' },

--- a/test/api.js
+++ b/test/api.js
@@ -77,29 +77,28 @@ export async function apiTest (fixtures) {
 
       strictEqual(wit.slice(0, 19), 'interface imports {');
 
-      const meta = [['language', [['javascript', '']]], ['processed-by', [['dummy-gen', 'test']]]];
-
-      const generatedComponent = await componentEmbed(null, wit, { dummy: true, metadata: meta });
+      const generatedComponent = await componentEmbed(null, wit, {
+        dummy: true,
+        metadata: [['language', [['javascript', '']]], ['processed-by', [['dummy-gen', 'test']]]]
+      });
       {
         const output = await print(generatedComponent);
         strictEqual(output.slice(0, 7), '(module');
       }
-
-      deepStrictEqual(metadata(generatedComponent), [
-        {
-          metaType: {
-            tag: 'module'
-          },
-          metadata: meta,
-          name: null
-        }
-      ]);
 
       const newComponent = await componentNew(generatedComponent);
       {
         const output = await print(newComponent);
         strictEqual(output.slice(0, 10), '(component');
       }
+
+      const meta = metadata(newComponent);
+      deepStrictEqual(meta[0].metaType, {
+        tag: 'component',
+        val: 4
+      });
+      console.log(JSON.stringify(meta, null, 2));
+      deepStrictEqual(meta[0].producers[0], meta[0])
     });
 
     test('Component new adapt', async () => {
@@ -117,7 +116,7 @@ export async function apiTest (fixtures) {
 
       deepStrictEqual(meta, [{
         metaType: { tag: 'module' },
-        metadata: [],
+        producers: [],
         name: null
       }]);
     });

--- a/test/cli.js
+++ b/test/cli.js
@@ -131,14 +131,12 @@ export async function cliTest (fixtures) {
         {
           const { stdout, stderr } = await exec(jsctPath, 'metadata-show', outFile, '--json');
           strictEqual(stderr, '');
-          deepStrictEqual(JSON.parse(stdout), [{
-            metaType: { tag: 'component' },
-            producers: [
-              ['language', [['javascript', '']]],
-              ['processed-by', [['dummy-gen', 'test']]]
-            ],
-            name: null
-          }]); 
+          const meta = JSON.parse(stdout);
+          deepStrictEqual(meta[0].metaType, { tag: 'component', val: 4 });
+          deepStrictEqual(meta[1].producers, [
+            ['processed-by', [['wit-component', '0.7.0'], ['dummy-gen', 'test']]],
+            ['language', [['javascript', '']]],
+          ]);
         }
       }
       finally {
@@ -175,7 +173,7 @@ export async function cliTest (fixtures) {
         strictEqual(stderr, '');
         deepStrictEqual(JSON.parse(stdout), [{
           metaType: { tag: 'module' },
-          metadata: [],
+          producers: [],
           name: null
         }]);
       }

--- a/test/cli.js
+++ b/test/cli.js
@@ -119,28 +119,26 @@ export async function cliTest (fixtures) {
           strictEqual(stdout.slice(0, 7), '(module');
         }
         {
+          const { stderr, stdout } = await exec(jsctPath, 'new', outFile, '-o', outFile);
+          strictEqual(stderr, '');
+          strictEqual(stdout, '');
+        }
+        {
+          const { stderr, stdout } = await exec(jsctPath, 'print', outFile);
+          strictEqual(stderr, '');
+          strictEqual(stdout.slice(0, 10), '(component');
+        }
+        {
           const { stdout, stderr } = await exec(jsctPath, 'metadata', outFile, '--json');
           strictEqual(stderr, '');
           deepStrictEqual(JSON.parse(stdout), [{
-            metaType: { tag: 'module' },
-            metadata: [
+            metaType: { tag: 'component' },
+            producers: [
               ['language', [['javascript', '']]],
               ['processed-by', [['dummy-gen', 'test']]]
             ],
             name: null
           }]); 
-        }
-
-        {
-          const { stderr, stdout } = await exec(jsctPath, 'new', outFile, '-o', outFile);
-          strictEqual(stderr, '');
-          strictEqual(stdout, '');
-        }
-
-        {
-          const { stderr, stdout } = await exec(jsctPath, 'print', outFile);
-          strictEqual(stderr, '');
-          strictEqual(stdout.slice(0, 10), '(component');
         }
       }
       finally {

--- a/test/cli.js
+++ b/test/cli.js
@@ -129,7 +129,7 @@ export async function cliTest (fixtures) {
           strictEqual(stdout.slice(0, 10), '(component');
         }
         {
-          const { stdout, stderr } = await exec(jsctPath, 'metadata', outFile, '--json');
+          const { stdout, stderr } = await exec(jsctPath, 'metadata-show', outFile, '--json');
           strictEqual(stderr, '');
           deepStrictEqual(JSON.parse(stdout), [{
             metaType: { tag: 'component' },
@@ -169,7 +169,7 @@ export async function cliTest (fixtures) {
     test('Extract metadata', async () => {
       try {
         const { stdout, stderr } = await exec(jsctPath,
-            'metadata',
+            'metadata-show',
             'test/fixtures/exitcode.wasm',
             '--json');
         strictEqual(stderr, '');


### PR DESCRIPTION
This adds the `jsct metadata` command from Wasm Tools as `wasm-tools metadata show`.

In addition `metadata` can be provided to the `embed` command and API so that when creating a component via a `new + embed` workflow, the producer metadata can be provided that way.

My tendency was not to provide the "add metadata" function since this is more designed to be a tool for consuming components than creating them, so specifically only targeting the `embed` workflow seems like it fulfills the major requirements of a standard component creation process embedding metadata such as is used in js-compute-runtime.

The embedding option didn't seem to pass through the metadata on its own so I had to add an additional write to this. Unsupported fields throw in the embedding process.